### PR TITLE
Fix cache download rename not awaiting

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -70,7 +70,7 @@ const downloadFile = async (url, targetFilePath, options) => {
 const downloadArchiveFromGithub = async () => {
   const downloadedFilePath = path.resolve(cacheDir, "download.file");
   await downloadFile(downloadLink, downloadedFilePath, { stream: true });
-  fs.rename(downloadedFilePath, cacheArchivePath);
+  await fs.rename(downloadedFilePath, cacheArchivePath);
 };
 
 const extractBinaries = async () => {


### PR DESCRIPTION
This fixes [Issue #89 in the nodegui repo](https://github.com/nodegui/nodegui/issues/89) (`I have to run npm install twice on MacOS 10.14.4`).

The issue was that the qode install does not wait for the rename of a download to finish before checking if the download exists. Running the install again works because the file is already there.

This fix adds `await` to the file rename.

